### PR TITLE
Use `poetry-core` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,5 @@ python = "^3.6"
 pytest = "^5.2"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This makes `strip-ansi` buildable with modern `poetry` installations, following the guidelines on
<https://python-poetry.org/docs/basic-usage/>